### PR TITLE
set cookie headers in doPoll and flushWaitingForPost

### DIFF
--- a/SocketIOClientSwift/SocketEngine.swift
+++ b/SocketIOClientSwift/SocketEngine.swift
@@ -201,7 +201,12 @@ public final class SocketEngine: NSObject, WebSocketDelegate, SocketLogClient {
         
         self.waitingForPoll = true
         let req = NSMutableURLRequest(URL: NSURL(string: self.urlPolling! + "&sid=\(self.sid)&b64=1")!)
-        
+      
+        if self.cookies != nil {
+            let headers = NSHTTPCookie.requestHeaderFieldsWithCookies(self.cookies!)
+            req.allHTTPHeaderFields = headers
+        }
+      
         self.doRequest(req)
     }
     
@@ -285,7 +290,12 @@ public final class SocketEngine: NSObject, WebSocketDelegate, SocketLogClient {
         self.postWait.removeAll(keepCapacity: false)
         
         let req = NSMutableURLRequest(URL: NSURL(string: self.urlPolling! + "&sid=\(self.sid)")!)
-        
+      
+        if self.cookies != nil {
+            let headers = NSHTTPCookie.requestHeaderFieldsWithCookies(self.cookies!)
+            req.allHTTPHeaderFields = headers
+        }
+      
         req.HTTPMethod = "POST"
         req.setValue("text/plain; charset=UTF-8", forHTTPHeaderField: "Content-Type")
         


### PR DESCRIPTION
I added this code to fix an issue I was having with sticky sessions on my load balancer.  When polling, only the first request was sending cookies.  This code adds cookies to subsequent polling GET's and the POST flush when polling.