### PR TITLE
Add ws(s) protocol "support"

### DIFF
--- a/SocketIOClientSwift/SocketIOClient.swift
+++ b/SocketIOClientSwift/SocketIOClient.swift
@@ -76,12 +76,14 @@ public final class SocketIOClient: NSObject, SocketEngineClient, SocketLogClient
     Create a new SocketIOClient. opts can be omitted
     */
     public init(var socketURL:String, opts:[String: AnyObject]? = nil) {
-        if socketURL["https://"].matches().count != 0 {
+        if (socketURL["https://"].matches().count != 0) || (socketURL["wss://"].matches().count != 0) {
             self._secure = true
         }
         
         socketURL = socketURL["http://"] ~= ""
         socketURL = socketURL["https://"] ~= ""
+        socketURL = socketURL["ws://"] ~= ""
+        socketURL = socketURL["wss://"] ~= ""
         
         self.socketURL = socketURL
         self.opts = opts


### PR DESCRIPTION
Since these protocols are often given instead of "http(s)" when connecting to a socket.io server
