### PR TITLE
Fix URL encoding for connectParams

### DIFF
--- a/Source/SocketEngine.swift
+++ b/Source/SocketEngine.swift
@@ -59,6 +59,8 @@ public final class SocketEngine: NSObject, SocketEnginePollable, SocketEngineWeb
     public private(set) var ws: WebSocket?
 
     public weak var client: SocketEngineClient?
+
+    private let allowedCharacterSet = NSCharacterSet(charactersInString: "!*'();:@&=+$,/?%#[]\" {}").invertedSet
     
     private weak var sessionDelegate: NSURLSessionDelegate?
 
@@ -248,12 +250,21 @@ public final class SocketEngine: NSObject, SocketEnginePollable, SocketEngineWeb
 
         if connectParams != nil {
             for (key, value) in connectParams! {
-                queryString += "&\(key)=\(value)"
+
+                let keyEsc = key.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+
+                if value is String {
+                    let valueEsc = (value as! String).stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+                    queryString += "&\(keyEsc)=\(valueEsc)"
+                } else {
+                    queryString += "&\(keyEsc)=\(value)"
+                }
+
             }
         }
 
-        urlWebSocket.query = urlWebSocket.query! + queryString
-        urlPolling.query = urlPolling.query! + queryString
+        urlWebSocket.percentEncodedQuery = urlWebSocket.query! + queryString
+        urlPolling.percentEncodedQuery = urlPolling.query! + queryString
         
         return (urlPolling.URL!, urlWebSocket.URL!)
     }

--- a/Source/SocketEngine.swift
+++ b/Source/SocketEngine.swift
@@ -60,8 +60,6 @@ public final class SocketEngine: NSObject, SocketEnginePollable, SocketEngineWeb
 
     public weak var client: SocketEngineClient?
 
-    private let allowedCharacterSet = NSCharacterSet(charactersInString: "!*'();:@&=+$,/?%#[]\" {}").invertedSet
-    
     private weak var sessionDelegate: NSURLSessionDelegate?
 
     private typealias Probe = (msg: String, type: SocketEnginePacketType, data: [NSData])

--- a/Source/SocketEngineSpec.swift
+++ b/Source/SocketEngineSpec.swift
@@ -63,16 +63,22 @@ import Foundation
 }
 
 extension SocketEngineSpec {
+    var allowedCharacterSet: NSCharacterSet {
+        return NSCharacterSet(charactersInString: "!*'();:@&=+$,/?%#[]\" {}").invertedSet
+    }
+
     var urlPollingWithSid: NSURL {
         let com = NSURLComponents(URL: urlPolling, resolvingAgainstBaseURL: false)!
-        com.percentEncodedQuery = com.percentEncodedQuery! + "&sid=\(sid)"
+        let sidEsc = sid.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+        com.percentEncodedQuery = com.percentEncodedQuery! + "&sid=\(sidEsc)"
         
         return com.URL!
     }
     
     var urlWebSocketWithSid: NSURL {
         let com = NSURLComponents(URL: urlWebSocket, resolvingAgainstBaseURL: false)!
-        com.percentEncodedQuery = com.percentEncodedQuery! + (sid == "" ? "" : "&sid=\(sid)")
+        let sidEsc = sid.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+        com.percentEncodedQuery = com.percentEncodedQuery! + (sid == "" ? "" : "&sid=\(sidEsc)")
         
         return com.URL!
     }

--- a/Source/SocketEngineSpec.swift
+++ b/Source/SocketEngineSpec.swift
@@ -65,14 +65,14 @@ import Foundation
 extension SocketEngineSpec {
     var urlPollingWithSid: NSURL {
         let com = NSURLComponents(URL: urlPolling, resolvingAgainstBaseURL: false)!
-        com.query = com.query! + "&sid=\(sid)"
+        com.percentEncodedQuery = com.percentEncodedQuery! + "&sid=\(sid)"
         
         return com.URL!
     }
     
     var urlWebSocketWithSid: NSURL {
         let com = NSURLComponents(URL: urlWebSocket, resolvingAgainstBaseURL: false)!
-        com.query = com.query! + (sid == "" ? "" : "&sid=\(sid)")
+        com.percentEncodedQuery = com.percentEncodedQuery! + (sid == "" ? "" : "&sid=\(sid)")
         
         return com.URL!
     }


### PR DESCRIPTION
Possible fix for https://github.com/nuclearace/Socket.IO-Client-Swift/issues/115
Encode manually and use `percentEncodedQuery` on `NSURLComponents`